### PR TITLE
Camera server: Add format storage and reset camera settings

### DIFF
--- a/examples/camera_server/camera_client.cpp
+++ b/examples/camera_server/camera_client.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <future>
 #include <iostream>
+#include <thread>
 
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/camera/camera.h>
@@ -54,7 +55,10 @@ int main(int argc, const char* argv[])
         std::cout << status << std::endl;
     });
 
-    auto operation_result = camera.take_photo();
+    auto operation_result = camera.format_storage();
+    std::cout << "format storage result : " << result << std::endl;
+
+    operation_result = camera.take_photo();
     std::cout << "take photo result : " << result << std::endl;
 
     operation_result = camera.start_video();

--- a/examples/camera_server/camera_server.cpp
+++ b/examples/camera_server/camera_server.cpp
@@ -119,7 +119,15 @@ int main(int argc, char** argv)
         }
         camera_server.respond_capture_status(capture_status);
     });
+
+    camera_server.subscribe_format_storage(
+        [](int storage_id) { std::cout << "format storage" << std::endl; });
+
+    camera_server.subscribe_reset_settings(
+        [](int camera_id) { std::cout << "reset camera settings" << std::endl; });
+
     // Then set the initial state of everything.
+
     // Finally call set_information() to "activate" the camera plugin.
 
     auto ret = camera_server.set_information({

--- a/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -133,6 +133,28 @@ CameraServer::Result CameraServer::respond_capture_status(CaptureStatus capture_
     return _impl->respond_capture_status(capture_status);
 }
 
+CameraServer::FormatStorageHandle
+CameraServer::subscribe_format_storage(const FormatStorageCallback& callback)
+{
+    return _impl->subscribe_format_storage(callback);
+}
+
+void CameraServer::unsubscribe_format_storage(FormatStorageHandle handle)
+{
+    _impl->unsubscribe_format_storage(handle);
+}
+
+CameraServer::ResetSettingsHandle
+CameraServer::subscribe_reset_settings(const ResetSettingsCallback& callback)
+{
+    return _impl->subscribe_reset_settings(callback);
+}
+
+void CameraServer::unsubscribe_reset_settings(ResetSettingsHandle handle)
+{
+    _impl->unsubscribe_reset_settings(handle);
+}
+
 bool operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs)
 {
     return (rhs.vendor_name == lhs.vendor_name) && (rhs.model_name == lhs.model_name) &&

--- a/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -480,6 +480,29 @@ CameraServerImpl::respond_capture_status(CameraServer::CaptureStatus capture_sta
         _image_capture_count);
 
     _server_component_impl->send_message(msg);
+    LogDebug() << "send capture status";
+    return CameraServer::Result::Success;
+}
+
+CameraServer::FormatStorageHandle
+CameraServerImpl::subscribe_format_storage(const CameraServer::FormatStorageCallback& callback)
+{
+    return _format_storage_callbacks.subscribe(callback);
+}
+void CameraServerImpl::unsubscribe_format_storage(CameraServer::FormatStorageHandle handle)
+{
+    _format_storage_callbacks.unsubscribe(handle);
+}
+
+CameraServer::ResetSettingsHandle
+CameraServerImpl::subscribe_reset_settings(const CameraServer::ResetSettingsCallback& callback)
+{
+    return _reset_settings_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_reset_settings(CameraServer::ResetSettingsHandle handle)
+{
+    _reset_settings_callbacks.unsubscribe(handle);
 }
 
 /**
@@ -671,14 +694,18 @@ CameraServerImpl::process_storage_format(const MavlinkCommandReceiver::CommandLo
     auto format = static_cast<bool>(command.params.param2);
     auto reset_image_log = static_cast<bool>(command.params.param3);
 
-    UNUSED(storage_id);
     UNUSED(format);
     UNUSED(reset_image_log);
+    if (_format_storage_callbacks.empty()) {
+        LogDebug() << "process storage format requested with no storage format subscriber";
+        return _server_component_impl->make_command_ack_message(
+            command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+    }
 
-    LogDebug() << "unsupported storage format request";
+    _format_storage_callbacks(storage_id);
 
     return _server_component_impl->make_command_ack_message(
-        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+        command, MAV_RESULT::MAV_RESULT_ACCEPTED);
 }
 
 std::optional<mavlink_message_t> CameraServerImpl::process_camera_capture_status_request(
@@ -715,10 +742,16 @@ CameraServerImpl::process_reset_camera_settings(const MavlinkCommandReceiver::Co
 
     UNUSED(reset);
 
-    LogDebug() << "unsupported reset camera settings request";
+    if (_reset_settings_callbacks.empty()) {
+        LogDebug() << "reset camera settings requested with no camera settings subscriber";
+        return _server_component_impl->make_command_ack_message(
+            command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+    }
+
+    _reset_settings_callbacks(0);
 
     return _server_component_impl->make_command_ack_message(
-        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+        command, MAV_RESULT::MAV_RESULT_ACCEPTED);
 }
 
 std::optional<mavlink_message_t>

--- a/src/mavsdk/plugins/camera_server/camera_server_impl.h
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.h
@@ -55,6 +55,14 @@ public:
     void unsubscribe_capture_status(CameraServer::CaptureStatusHandle handle);
     CameraServer::Result respond_capture_status(CameraServer::CaptureStatus capture_status) const;
 
+    CameraServer::FormatStorageHandle
+    subscribe_format_storage(const CameraServer::FormatStorageCallback& callback);
+    void unsubscribe_format_storage(CameraServer::FormatStorageHandle handle);
+
+    CameraServer::ResetSettingsHandle
+    subscribe_reset_settings(const CameraServer::ResetSettingsCallback& callback);
+    void unsubscribe_reset_settings(CameraServer::ResetSettingsHandle handle);
+
 private:
     enum StatusFlags {
         IN_PROGRESS = 1 << 0,
@@ -84,6 +92,8 @@ private:
     CallbackList<CameraServer::CameraMode> _set_camera_mode_callbacks{};
     CallbackList<int32_t> _storage_information_callbacks{};
     CallbackList<int32_t> _capture_status_callbacks{};
+    CallbackList<int32_t> _format_storage_callbacks{};
+    CallbackList<int32_t> _reset_settings_callbacks{};
 
     MavlinkCommandReceiver::CommandLong _last_take_photo_command;
 

--- a/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.h
+++ b/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.h
@@ -570,6 +570,48 @@ public:
     Result respond_capture_status(CaptureStatus capture_status) const;
 
     /**
+     * @brief Callback type for subscribe_format_storage.
+     */
+    using FormatStorageCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_format_storage.
+     */
+    using FormatStorageHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to format storage requests. Each request received should response to using
+     * FormatStorageResponse
+     */
+    FormatStorageHandle subscribe_format_storage(const FormatStorageCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_format_storage
+     */
+    void unsubscribe_format_storage(FormatStorageHandle handle);
+
+    /**
+     * @brief Callback type for subscribe_reset_settings.
+     */
+    using ResetSettingsCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_reset_settings.
+     */
+    using ResetSettingsHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to reset settings requests. Each request received should response to using
+     * ResetSettingsResponse
+     */
+    ResetSettingsHandle subscribe_reset_settings(const ResetSettingsCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_reset_settings
+     */
+    void unsubscribe_reset_settings(ResetSettingsHandle handle);
+
+    /**
      * @brief Copy constructor.
      */
     CameraServer(const CameraServer& other);


### PR DESCRIPTION
  * Add format storage in camera server and example code;
  * Add reset camrea settings in camera server. The camera.proto has no reset interface, so can't implement example code;